### PR TITLE
Fix of incorrect FEN interpretation

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,22 +1,15 @@
 {
-  "auth": "zef:vushu",
-  "build-depends": [
-  ],
-  "depends": [
-  ],
-  "description": "Grammar for Forsyth-Edwards Notation (FEN) used for describing positions of a chess game",
-  "license": "Artistic-2.0",
-  "name": "FEN::Grammar",
-  "provides": {
-    "FEN::Grammar": "lib/FEN/Grammar.rakumod",
-    "FEN::Actions": "lib/FEN/Actions.rakumod",
-    "FEN::Utils": "lib/FEN/Utils.rakumod",
-    "FEN::Result": "lib/FEN/Result.rakumod"
-  },
-  "resources": [
-  ],
-  "test-depends": [
-  ],
-  "version": "0.0.5",
-  "source-url": "https://github.com/vushu/fen-grammar.git"
+    "name": "FEN::Grammar",
+    "description": "Grammar for Forsyth-Edwards Notation (FEN) used for describing positions of a chess game",
+    "version": "0.0.6",
+    "auth": "zef:vushu",
+    "build-depends": [],
+    "provides": {
+        "FEN::Grammar": "lib/FEN/Grammar.rakumod",
+        "FEN::Actions": "lib/FEN/Actions.rakumod",
+        "FEN::Utils": "lib/FEN/Utils.rakumod",
+        "FEN::Result": "lib/FEN/Result.rakumod"
+    },
+    "license": "Artistic-2.0",
+    "source-url": "https://github.com/vushu/fen-grammar.git"
 }

--- a/lib/FEN/Actions.rakumod
+++ b/lib/FEN/Actions.rakumod
@@ -39,11 +39,12 @@ method rank($/) {
     my @chess-pieces;
     for $<position>.kv -> $idx, $pos {
         if $pos<chess-piece> {
-            my $p = $offset > 0 ?? max(($offset + $idx - 1), 0) !! $idx;
+            my $p = $offset > 0 ?? max($offset, 0) !! $idx;
             @chess-pieces.push(($p, ~$pos<chess-piece>));
+            $offset++
         }
-        else { # else is empty-space 
-            $offset = +$pos;
+        else { # else is empty-space
+            $offset += +$pos;
         }
     }
     make @chess-pieces;

--- a/xt/03-ascii-fen-multi-roundtrip.rakutest
+++ b/xt/03-ascii-fen-multi-roundtrip.rakutest
@@ -1,0 +1,42 @@
+use lib 'lib';
+use Test;
+use FEN::Grammar;
+use FEN::Actions;
+use FEN::Utils;
+use FEN::Result;
+
+plan *;
+
+my $n-boards = 1000;
+
+sub generate-random-chess-position(Numeric:D $density = 0.3) {
+    my @pieces = <K Q R B N P k q r b n p>;
+    my @empty = ('.') xx 32;
+    my @board = (rand ≤ $density ?? @pieces.pick !! '.') xx 64;
+    @board = @board.rotor(8);
+    my @rows = do for @board -> @row {
+        '[' ~ @row.join(' ') ~ ']';
+    }
+    return @rows.join("\n");
+}
+
+my @matrices = generate-random-chess-position( rand ) xx $n-boards;
+
+for @matrices -> $ascii-matrix {
+    my $fen = FEN::Utils::ascii-to-fen($ascii-matrix);
+
+    # Re-parsing it
+    my $actions = FEN::Actions.new;
+    my $match = FEN::Grammar.parse($fen, :$actions);
+    #ok $match, "Successfully parsed FEN";
+
+    my $result = $match.made;
+    #ok $result.ranks, "Successfully created ranks list";
+
+    is
+            FEN::Utils::to-matrix($result.ranks).join("\n").trim,
+            $ascii-matrix.subst(/ <[\[\]]> /, :g).trim,
+            'Roundtrip equivalence';
+}
+
+done-testing;


### PR DESCRIPTION
This PR fixes the interpretation bug reported here: https://github.com/vushu/fen-grammar/issues/6

The ".xt/" directory has a test file that makes multiple (100s or 1000s) round-trip ASCII-FEN translation tests.
"FEN::Grammar:ver<0.05>" fails ≈ 63% of them. This new version -- 0.0.6 -- passes all of them.